### PR TITLE
Add manual confetti trigger

### DIFF
--- a/app.js
+++ b/app.js
@@ -1008,7 +1008,8 @@ if (!s.settings.officeTz) s.settings.officeTz = '';
     }catch(e){ return defaults(); }
   }
   const state = load();
-  let todayCelebrated = false;
+    // Avoid launching confetti on initial page load
+    let todayCelebrated = true;
   function launchConfetti(){
     if (typeof confetti !== 'function') return;
     const duration = 5000;
@@ -3203,11 +3204,13 @@ function bootstrap(){
     afterLayout();
   centerMainCards();
   updateLocalTimes();
-  initNotificationsUI();
-  startNotificationTicker();
+    initNotificationsUI();
+    startNotificationTicker();
 
-  // 🔎 Customers search + status filter
-  const searchEl = document.getElementById('search');
+    $('#testConfettiBtn')?.addEventListener('click', launchConfetti);
+
+    // 🔎 Customers search + status filter
+    const searchEl = document.getElementById('search');
   const clearSearchBtn = document.getElementById('clearSearch');
   if (searchEl){
     let raf = 0;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <div class="space"></div>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☀️ Light</button>
       <button id="moreBtn" class="toggle" aria-label="More settings">☰ More</button>
+      <button id="testConfettiBtn" class="toggle" aria-label="Test confetti">🎉 Test</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Prevent confetti from launching on page refresh
- Add "Test confetti" button to manually trigger celebration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf3cbd29c832693fb6a67af5ef62e