### PR TITLE
Fix confetti test button and suppress reload confetti

### DIFF
--- a/app.js
+++ b/app.js
@@ -1009,7 +1009,8 @@ if (!s.settings.officeTz) s.settings.officeTz = '';
   }
   const state = load();
     // Avoid launching confetti on initial page load
-    let todayCelebrated = true;
+    const todayStr = fmt(today());
+    let todayCelebrated = state.tasks.filter(t=>t.status!=='done' && t.date===todayStr).length === 0;
   function launchConfetti(){
     if (typeof confetti !== 'function') return;
     const duration = 5000;
@@ -3204,10 +3205,11 @@ function bootstrap(){
     afterLayout();
   centerMainCards();
   updateLocalTimes();
-    initNotificationsUI();
-    startNotificationTicker();
 
     $('#testConfettiBtn')?.addEventListener('click', launchConfetti);
+
+    initNotificationsUI();
+    startNotificationTicker();
 
     // 🔎 Customers search + status filter
     const searchEl = document.getElementById('search');

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       <div class="space"></div>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☀️ Light</button>
       <button id="moreBtn" class="toggle" aria-label="More settings">☰ More</button>
-      <button id="testConfettiBtn" class="toggle" aria-label="Test confetti">🎉 Test</button>
+      <button id="testConfettiBtn" type="button" class="toggle" aria-label="Test confetti">🎉 Test</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Initialize confetti celebration state based on remaining tasks so reloads don't re-trigger confetti
- Ensure the "Test" button works and can't submit forms
- Attach the test button listener earlier during bootstrap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4d4a75483268f33bddb91eb8a13