### PR TITLE
Fix invisible postpone modal overlay

### DIFF
--- a/app.css
+++ b/app.css
@@ -549,6 +549,16 @@ body.light .ovr-list li{ background:#fff }
   width:min(560px,92vw); background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:12px; box-shadow:var(--sh-2);
   animation:pop .16s ease-out;
 }
+
+#postponePop{
+  position:fixed; inset:0; display:none; align-items:center; justify-content:center;
+  background:rgba(0,0,0,.55); backdrop-filter:blur(6px); z-index:11000; padding:18px;
+  margin:0;
+}
+#postponePop .sheet{
+  width:min(560px,92vw); background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:12px; box-shadow:var(--sh-2);
+  animation:pop .16s ease-out;
+}
 /* Client wider than Type */
 #customTaskPop .row { grid-template-columns: 2fr 1fr; }
 #ctClient { width: 100%; }


### PR DESCRIPTION
## Summary
- style postpone modal container to cover viewport and center its sheet
- prevent hidden margin offset so overlay isn't displaced

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ab2f25548326b4bd97b47289b9a0