### PR TITLE
Fix agenda sort direction

### DIFF
--- a/app.js
+++ b/app.js
@@ -2072,7 +2072,7 @@ function renderGroupedByClient(container, items){
     const items = state.tasks
       .filter(t => t.date===f && matchesFilter(t) && matchesShow(t))
       .sort(sortTasksForMode);
-    if (sortDir === 'new') items.reverse();
+    if (sortDir === 'old') items.reverse();
     cont.innerHTML = '';
     if(items.length===0){ cont.innerHTML = `<div class="tiny">No tasks for ${f}.</div>`; updateProgress(); updateLocalTimes(); return; }
     if (sortMode === 'client') renderGroupedByClient(cont, items);
@@ -2085,13 +2085,13 @@ function renderGroupedByClient(container, items){
     const cont = $('#agenda'); cont.innerHTML = '';
     const days = Math.ceil((to-from)/86400000)+1;
     const dayList = Array.from({length:days}, (_,i)=>addDays(from,i));
-    if (sortDir === 'new') dayList.reverse();
+    if (sortDir === 'old') dayList.reverse();
     for(const d of dayList){
       const f = fmt(d);
       const items = state.tasks
         .filter(t => t.date===f && matchesFilter(t) && matchesShow(t))
         .sort(sortTasksForMode);
-      if (sortDir === 'new') items.reverse();
+      if (sortDir === 'old') items.reverse();
       const head = document.createElement('div'); head.className = 'tiny'; head.innerHTML = `<div class="badge mono">${f}</div>`;
       cont.appendChild(head);
       if(items.length===0){ const none = document.createElement('div'); none.className='tiny'; none.textContent='No tasks'; cont.appendChild(none); }


### PR DESCRIPTION
## Summary
- Correct agenda range sort logic so that selecting **Old** displays earliest leads first and **New** shows latest first

## Testing
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c71155ccc48326b812c1a7a059fda3